### PR TITLE
增加 bootstrapExpect 参数以启动 consul

### DIFF
--- a/deploy_yaml/base/consul-server.yaml
+++ b/deploy_yaml/base/consul-server.yaml
@@ -6,6 +6,7 @@ server:
     replicas: 1
     storage: 10Gi
     storageClass: nfs-consul
+    bootstrapExpect: 1
 client:
     enabled: false
 meshGateway:


### PR DESCRIPTION
根据 https://www.consul.io/docs/k8s/helm.html#v-server-bootstrapexpect 这个参数默认是3, 而他应该小于等于 server.replicas